### PR TITLE
Notebook: cross-platform paths; create "out" directory; fixed length filenames

### DIFF
--- a/GeneticDrawing.ipynb
+++ b/GeneticDrawing.ipynb
@@ -7,6 +7,7 @@
    "outputs": [],
    "source": [
     "import cv2\n",
+    "import os\n",
     "import time\n",
     "from IPython.display import clear_output\n",
     "from genetic_drawing import *"
@@ -43,8 +44,9 @@
    "outputs": [],
    "source": [
     "#save all the images from the image buffer\n",
+    "os.mkdir(\"out\")\n",
     "for i in range(len(gen.imgBuffer)):\n",
-    "    cv2.imwrite(\"out/\" + str(i) +'.png', gen.imgBuffer[i])\n",
+    "    cv2.imwrite(os.path.join(\"out\", f\"{i:06d}.png\"), gen.imgBuffer[i])\n",
     "#if you want to save only last image, run below\n",
     "# cv2.imwrite(\"out/final.png', out)"
    ]


### PR DESCRIPTION
Just some minor changes for the image-output cell of the notebook. 

- make it cross-platform
- have the output files sorted correctly in naive file managers/image viewers

(As regards the `mkdir`: I'm not sure wheter you'd prefer adding a `out` folder in the repo instead)